### PR TITLE
1.0.1-SNAPSHOT: Build workflow and dependency updates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,19 +6,21 @@ name: Java CI with Maven
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.11
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 21
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>population-records</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>population-records</name>
 
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>uk.ac.standrews.cs</groupId>
             <artifactId>ciesvium</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/uk/ac/standrews/cs/population_records/PopulationDataSet.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/PopulationDataSet.java
@@ -27,7 +27,6 @@ import uk.ac.standrews.cs.utilities.dataset.encrypted.EncryptedDataSet;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 


### PR DESCRIPTION
## Overview
Very small patch updating dependency for [Ciesvium](https://github.com/stacs-srg/ciesvium/) to gain new `Charset` setting functionality and updates build pipeline to an up-to-data JDK.

Closes #1, closes #2 

## Changelist
**Features:**
- Updates [Ciesvium](https://github.com/stacs-srg/ciesvium/) dependency to `1.1.0-SNAPSHOT` to add support for new override-able `getCharset()` function in `DataSet`, which can be used to set the `Charset` to use for decoding the input for a `PopulationDataSet`.

**Repository:**
- Updates build workflow to use Java 21 JDK.

**Refactoring:**
- Removes unused imports from `PopulationDataSet`.