### PR TITLE
1.0.2-SNAPSHOT: Updates and type-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides some Java utility classes for manipulating population reco
 <dependency>
     <groupId>uk.ac.standrews.cs</groupId>
     <artifactId>population-records</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 </dependency>
 ...
 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>uk.ac.standrews.cs</groupId>
             <artifactId>neo-storr</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>uk.ac.standrews.cs</groupId>
             <artifactId>ciesvium</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
             <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version> <!-- Use the latest version -->
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>population-records</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>population-records</name>
 

--- a/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
@@ -131,7 +131,7 @@ public class RecordRepository implements AutoCloseable {
 
         return () -> new Iterator<>() {
 
-            final List<Long> object_ids = bucket.getObjectIds();
+            final List<String> object_ids = bucket.getObjectIds();
             final int bucket_size = object_ids.size();
             int next_index = 0;
 

--- a/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
@@ -86,6 +86,7 @@ public class RecordRepository implements AutoCloseable {
 
     public static final int RECORDS_IMPORTED_PER_TRANSACTION = 10000;
 
+    @SuppressWarnings("unchecked")
     private <T extends LXP> void importRecords(IBucket<T> bucket, Iterable<LXP> records) throws BucketException {
 
         final ITransactionManager transaction_manager = Store.getInstance().getTransactionManager();
@@ -251,7 +252,7 @@ public class RecordRepository implements AutoCloseable {
         return new String[]{BIRTHS_BUCKET_NAME, DEATHS_BUCKET_NAME, MARRIAGES_BUCKET_NAME};
     }
 
-    public IBucket getBucket(String bucketName) {
+    public IBucket<?> getBucket(String bucketName) {
         switch (bucketName) {
             case BIRTHS_BUCKET_NAME:
                 return births;

--- a/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/RecordRepository.java
@@ -86,7 +86,6 @@ public class RecordRepository implements AutoCloseable {
 
     public static final int RECORDS_IMPORTED_PER_TRANSACTION = 10000;
 
-    @SuppressWarnings("unchecked")
     private <T extends LXP> void importRecords(IBucket<T> bucket, Iterable<LXP> records) throws BucketException {
 
         final ITransactionManager transaction_manager = Store.getInstance().getTransactionManager();
@@ -252,7 +251,7 @@ public class RecordRepository implements AutoCloseable {
         return new String[]{BIRTHS_BUCKET_NAME, DEATHS_BUCKET_NAME, MARRIAGES_BUCKET_NAME};
     }
 
-    public IBucket<?> getBucket(String bucketName) {
+    public IBucket getBucket(String bucketName) {
         switch (bucketName) {
             case BIRTHS_BUCKET_NAME:
                 return births;

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
@@ -53,7 +53,7 @@ public class Birth extends StaticLXP {
         super();
     }
 
-    public Birth(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+    public Birth(long persistent_object_id, Map<String, Object> properties, IBucket<Birth> bucket) throws PersistentObjectException {
 
         super(persistent_object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
@@ -53,7 +53,7 @@ public class Birth extends StaticLXP {
         super();
     }
 
-    public Birth(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+    public Birth(String persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
 
         super(persistent_object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"unused", "WeakerAccess"})
+@SuppressWarnings("WeakerAccess")
 public class Birth extends StaticLXP {
 
     public static final String ROLE_BABY = "ROLE_BABY";

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Birth.java
@@ -53,7 +53,7 @@ public class Birth extends StaticLXP {
         super();
     }
 
-    public Birth(long persistent_object_id, Map<String, Object> properties, IBucket<Birth> bucket) throws PersistentObjectException {
+    public Birth(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
 
         super(persistent_object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"unused", "WeakerAccess"})
+@SuppressWarnings("WeakerAccess")
 public class Death extends StaticLXP {
 
     public static final String ROLE_DECEASED = "ROLE_DECEASED";

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
@@ -57,7 +57,7 @@ public class Death extends StaticLXP {
         super();
     }
 
-    public Death(long persistent_Object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+    public Death(String persistent_Object_id, Map properties, IBucket bucket) throws PersistentObjectException {
 
         super(persistent_Object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
@@ -57,7 +57,7 @@ public class Death extends StaticLXP {
         super();
     }
 
-    public Death(long persistent_Object_id, Map<String, Object> properties, IBucket<Death> bucket) throws PersistentObjectException {
+    public Death(long persistent_Object_id, Map properties, IBucket bucket) throws PersistentObjectException {
 
         super(persistent_Object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Death.java
@@ -57,7 +57,7 @@ public class Death extends StaticLXP {
         super();
     }
 
-    public Death(long persistent_Object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+    public Death(long persistent_Object_id, Map<String, Object> properties, IBucket<Death> bucket) throws PersistentObjectException {
 
         super(persistent_Object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("WeakerAccess")
 public class Marriage extends StaticLXP {
 
     public static final String ROLE_BRIDE = "ROLE_BRIDE";

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
@@ -60,7 +60,7 @@ public class Marriage extends StaticLXP {
         super();
     }
 
-    public Marriage(long persistent_object_id, Map<String, Object> properties, IBucket<Marriage> bucket) throws PersistentObjectException {
+    public Marriage(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
 
         super(persistent_object_id, properties, bucket);
     }

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
@@ -60,8 +60,8 @@ public class Marriage extends StaticLXP {
         super();
     }
 
-    public Marriage(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
-
+    public Marriage(String persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+        
         super(persistent_object_id, properties, bucket);
     }
 

--- a/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
+++ b/src/main/java/uk/ac/standrews/cs/population_records/record_types/Marriage.java
@@ -60,7 +60,7 @@ public class Marriage extends StaticLXP {
         super();
     }
 
-    public Marriage(long persistent_object_id, Map properties, IBucket bucket) throws PersistentObjectException {
+    public Marriage(long persistent_object_id, Map<String, Object> properties, IBucket<Marriage> bucket) throws PersistentObjectException {
 
         super(persistent_object_id, properties, bucket);
     }

--- a/src/test/java/uk/ac/standrews/cs/population_records/NormalisationTest.java
+++ b/src/test/java/uk/ac/standrews/cs/population_records/NormalisationTest.java
@@ -16,9 +16,9 @@
  */
 package uk.ac.standrews.cs.population_records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NormalisationTest {
 


### PR DESCRIPTION
## Overview
Small patch, mostly containing updates to dependencies used by the package. Updates unit-testing to use JUnit5 and updates [Ciesvium](https://github.com/stacs-srg/ciesvium) dependency to [`1.1.1-SNAPSHOT`](https://github.com/stacs-srg/ciesvium/pull/6) to take advantage of patches to the `EncryptedDataSet` package.

Closes #4, closes #5, closes #9, closes #10 
## Changelist
**Dependencies:**
- Updates Ciesvium dependency to [`1.1.1-SNAPSHOT`](https://github.com/stacs-srg/ciesvium/pull/6).
- Updates [`neo-storr`](https://github.com/stacs-srg/neo-storr/) dependency to [`1.0.1-SNAPSHOT`](https://github.com/stacs-srg/neo-storr/pull/11).
- Introduces `JUnit5` dependency and adapts unit tests to use this.

**Refactoring:**
- Refactors objects to use `String` data-type instead of `long` for ids for compatibility with Neo4J Driver 5+ (as introduced in [`neo-storr 1.0.1-SNAPSHOT`](https://github.com/stacs-srg/neo-storr/pull/11).